### PR TITLE
Motor driver

### DIFF
--- a/boards/native/Makefile.features
+++ b/boards/native/Makefile.features
@@ -4,6 +4,7 @@ FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_qdec
+FEATURES_PROVIDED += periph_pwm
 
 # Various other features (if any)
 FEATURES_PROVIDED += ethernet

--- a/boards/native/board.c
+++ b/boards/native/board.c
@@ -25,11 +25,10 @@
 #define SIMU_ENC_BUFSIZE    3
 extern int32_t qdecs_value[QDEC_NUMOF];
 
-void native_motor_driver_qdec_simulation( \
-    const motor_driver_t motor_driver, uint8_t motor_id, \
+void native_motor_driver_qdec_simulation(
+    const motor_driver_t motor_driver, uint8_t motor_id,
     motor_direction_t direction, uint16_t pwm_duty_cycle)
 {
-    (void) motor_driver;
     static int16_t simu_motor_encoder[QDEC_NUMOF][SIMU_ENC_BUFSIZE] = {0,};
 
     uint32_t i = 0, id = 0;
@@ -38,7 +37,7 @@ void native_motor_driver_qdec_simulation( \
     int32_t pwm_value = direction ? -pwm_duty_cycle : pwm_duty_cycle;
 
     for (i = 0; i < motor_driver; i++) {
-        const motor_driver_config_t motor_driver_conf = \
+        const motor_driver_config_t motor_driver_conf =
             motor_driver_config[motor_driver];
         id += motor_driver_conf.nb_motors;
     }
@@ -46,8 +45,7 @@ void native_motor_driver_qdec_simulation( \
 
     if (id < QDEC_NUMOF) {
 
-        for (i = 0; i < SIMU_ENC_BUFSIZE - 1; i++)
-        {
+        for (i = 0; i < SIMU_ENC_BUFSIZE - 1; i++) {
             s += simu_motor_encoder[id][i];
             simu_motor_encoder[id][i] = simu_motor_encoder[id][i+1];
         }

--- a/boards/native/board.c
+++ b/boards/native/board.c
@@ -1,0 +1,74 @@
+/**
+ * Native Board board implementation
+ *
+ * Copyright (C) 2018 Gilles DOFFE <g.doffe@gmail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ *
+ * @ingroup boards_native
+ * @{
+ * @file
+ * @author  Gilles DOFFE <g.doffe@gmail.com>
+ * @}
+ */
+#include <inttypes.h>
+#include <stdio.h>
+
+/* RIOT includes */
+#include <board.h>
+#include <log.h>
+
+#ifdef QDEC_NUMOF
+
+#define SIMU_ENC_BUFSIZE    3
+extern int32_t qdecs_value[QDEC_NUMOF];
+
+void native_motor_driver_qdec_simulation( \
+    const motor_driver_t motor_driver, uint8_t motor_id, \
+    motor_direction_t direction, uint16_t pwm_duty_cycle)
+{
+    (void) motor_driver;
+    static int16_t simu_motor_encoder[QDEC_NUMOF][SIMU_ENC_BUFSIZE] = {0,};
+
+    uint32_t i = 0, id = 0;
+    int32_t s = 0;
+
+    int32_t pwm_value = direction ? -pwm_duty_cycle : pwm_duty_cycle;
+
+    for (i = 0; i < motor_driver; i++) {
+        const motor_driver_config_t motor_driver_conf = \
+            motor_driver_config[motor_driver];
+        id += motor_driver_conf.nb_motors;
+    }
+    id += motor_id;
+
+    if (id < QDEC_NUMOF) {
+
+        for (i = 0; i < SIMU_ENC_BUFSIZE - 1; i++)
+        {
+            s += simu_motor_encoder[id][i];
+            simu_motor_encoder[id][i] = simu_motor_encoder[id][i+1];
+        }
+
+        s = (s + simu_motor_encoder[id][i] + pwm_value) / (SIMU_ENC_BUFSIZE + 1);
+        simu_motor_encoder[id][i] = s;
+        qdecs_value[id] = s;
+
+        LOG_DEBUG("MOTOR-DRIVER=%u"             \
+            "    MOTOR_ID = %u"                 \
+            "    PWM_VALUE = %d"                \
+            "    QDEC_ID = %"PRIu32""           \
+            "    QDEC_AVERAGE = %d\n",          \
+            motor_driver, motor_id, pwm_value, id, s);
+    }
+    else {
+        LOG_ERROR("MOTOR-DRIVER=%u"             \
+            "    MOTOR_ID = %u"                 \
+            "    no QDEC device associated",    \
+            motor_driver, motor_id);
+    }
+}
+
+#endif /* QDEC_NUMOF */

--- a/boards/native/include/board.h
+++ b/boards/native/include/board.h
@@ -131,6 +131,42 @@ void native_motor_driver_qdec_simulation( \
     const motor_driver_t motor_driver, uint8_t motor_id, \
     motor_direction_t direction, uint16_t pwm_duty_cycle);
 
+/**
+ * @brief Describe DC motor with PWM channel and GPIOs
+ */
+static const motor_driver_config_t motor_driver_config[] = {
+    {
+        .mode            = MOTOR_DRIVER_1_DIR_BRAKE,
+        .pwm_dev         = 0,
+        .pwm_frequency   = 20000U,
+        .pwm_resolution  = 1000U,
+        .nb_motors       = 2,
+        .motors          = {
+            {
+                .pwm_channel            = 0,
+                .gpio_enable            = GPIO_PIN(0, 0),
+                .gpio_dir0              = GPIO_PIN(0, 0),
+                .gpio_dir1_or_brake     = GPIO_PIN(0, 0),
+                .gpio_dir_reverse       = 0,
+                .gpio_enable_invert     = 0,
+                .gpio_brake_invert      = 0,
+            },
+            {
+                .pwm_channel            = 1,
+                .gpio_enable            = GPIO_PIN(0, 0),
+                .gpio_dir0              = GPIO_PIN(0, 0),
+                .gpio_dir1_or_brake     = GPIO_PIN(0, 0),
+                .gpio_dir_reverse       = 1,
+                .gpio_enable_invert     = 0,
+                .gpio_brake_invert      = 0,
+            },
+        },
+        .cb = native_motor_driver_qdec_simulation,
+    },
+};
+
+#define MOTOR_DRIVER_NUMOF           (sizeof(motor_driver_config) / sizeof(motor_driver_config[0]))
+
 #ifdef __cplusplus
 }
 #endif

--- a/boards/native/include/board.h
+++ b/boards/native/include/board.h
@@ -24,6 +24,9 @@
 
 #include <stdint.h>
 
+/* RIOT includes */
+#include <motor_driver.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -123,6 +126,10 @@ extern mtd_dev_t *mtd0;
 #endif
 /** @} */
 #endif
+
+void native_motor_driver_qdec_simulation( \
+    const motor_driver_t motor_driver, uint8_t motor_id, \
+    motor_direction_t direction, uint16_t pwm_duty_cycle);
 
 #ifdef __cplusplus
 }

--- a/boards/nucleo-f446re/include/board.h
+++ b/boards/nucleo-f446re/include/board.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2018 Gilles DOFFE <g.doffe@gmail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    boards_nucleo-f446re STM32 Nucleo-F446RE
+ * @ingroup     boards_common_nucleo64
+ * @brief       Support for the STM32 Nucleo-F446RE
+ * @{
+ *
+ * @file
+ * @brief       Common pin definitions and board configuration options
+ *
+ * @author      Gilles DOFFE <g.doffe@gmail.com>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include "board_nucleo.h"
+#include "motor_driver.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Describe DC motors with PWM channel and GPIOs
+ */
+static const motor_driver_config_t motor_driver_config[] = {
+    {
+        .mode            = MOTOR_DRIVER_1_DIR,
+        .mode_brake      = MOTOR_BRAKE_LOW,
+        .pwm_dev         = 1,
+        .pwm_frequency   = 20000U,
+        .pwm_resolution  = 2250U,
+        .nb_motors       = 2,
+        .motors          = {
+            {
+                .pwm_channel            = 0,
+                .gpio_enable            = GPIO_UNDEF,
+                .gpio_dir0              = GPIO_PIN(PORT_A, 11),
+                .gpio_dir1_or_brake     = GPIO_UNDEF,
+                .gpio_dir_reverse       = 0,
+                .gpio_enable_invert     = 0,
+                .gpio_brake_invert      = 0,
+            },
+            {
+                .pwm_channel            = 2,
+                .gpio_enable            = GPIO_UNDEF,
+                .gpio_dir0              = GPIO_PIN(PORT_A, 12),
+                .gpio_dir1_or_brake     = GPIO_UNDEF,
+                .gpio_dir_reverse       = 0,
+                .gpio_enable_invert     = 0,
+                .gpio_brake_invert      = 0,
+            },
+        },
+        .cb = NULL,
+    },
+};
+
+#define MOTOR_DRIVER_NUMOF           (sizeof(motor_driver_config) / sizeof(motor_driver_config[0]))
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/cpu/native/Makefile.features
+++ b/cpu/native/Makefile.features
@@ -2,3 +2,4 @@ FEATURES_PROVIDED += cpp
 FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_hwrng
 FEATURES_PROVIDED += periph_pm
+FEATURES_PROVIDED += periph_pwm

--- a/cpu/native/include/periph_conf.h
+++ b/cpu/native/include/periph_conf.h
@@ -73,6 +73,13 @@
 /** @} */
 
 /**
+ * @brief PWM configuration
+ */
+#ifndef PWM_NUMOF
+#define PWM_NUMOF (8U)
+#endif
+
+/**
  * @brief QDEC configuration
  */
 #ifndef QDEC_NUMOF

--- a/cpu/native/periph/gpio.c
+++ b/cpu/native/periph/gpio.c
@@ -23,7 +23,10 @@ int gpio_init(gpio_t pin, gpio_mode_t mode) {
   (void) pin;
   (void) mode;
 
-  return -1;
+  if (mode >= GPIO_OUT)
+    return 0;
+  else
+    return -1;
 }
 
 int gpio_read(gpio_t pin) {

--- a/cpu/native/periph/pwm.c
+++ b/cpu/native/periph/pwm.c
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2018 Gilles DOFFE <g.doffe@gmail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_native
+ * @ingroup     drivers_periph_pwm
+ * @{
+ *
+ * @file
+ * @brief       Low-level PWM driver implementation
+ *
+ * @author      Gilles DOFFE <g.doffe@gmail.com>
+ * @}
+ */
+
+#include <errno.h>
+
+#include "periph/pwm.h"
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+#ifdef PWM_NUMOF
+
+#define NATIVE_PWM_SPEED    1000000
+#define NATIVE_PWM_NB_CHAN  2
+#define NATIVE_PWM_MAX      65535
+
+typedef struct {
+    uint16_t duty_cycle;
+    uint8_t on;
+} native_pwm_t;
+
+native_pwm_t pwms[PWM_NUMOF][NATIVE_PWM_NB_CHAN];
+
+uint32_t pwm_init(pwm_t pwm, pwm_mode_t mode, uint32_t freq, uint16_t res)
+{
+    uint8_t i = 0;
+
+    (void) mode;
+    (void) freq;
+    (void) res;
+
+    if (pwm >= PWM_NUMOF)
+    {
+        errno = ENODEV;
+        goto pwm_init_err;
+    }
+
+    /* reset pwm channels */
+    for (i = 0; i < NATIVE_PWM_NB_CHAN; i++)
+    {
+        pwms[pwm][i].duty_cycle = 0;
+        pwms[pwm][i].on = 0;
+    }
+
+    return freq;
+
+pwm_init_err:
+    return 0;
+}
+
+uint8_t pwm_channels(pwm_t pwm)
+{
+    (void) pwm;
+    return NATIVE_PWM_NB_CHAN;
+}
+
+void pwm_set(pwm_t pwm, uint8_t channel, uint16_t value)
+{
+    assert(pwm < PWM_NUMOF);
+
+    /* set new value */
+    pwms[pwm][channel].duty_cycle = value;
+    DEBUG("%s pwms[%u][%u] = %u\n", __func__, pwm, channel, value);
+}
+
+void pwm_poweron(pwm_t pwm)
+{
+    uint8_t i = 0;
+
+    assert(pwm < PWM_NUMOF);
+    /* reset pwm channels */
+    for (i = 0; i < NATIVE_PWM_NB_CHAN; i++)
+        pwms[pwm][i].on = 1;
+}
+
+void pwm_poweroff(pwm_t pwm)
+{
+    uint8_t i = 0;
+
+    assert(pwm < PWM_NUMOF);
+    /* reset pwm channels */
+    for (i = 0; i < NATIVE_PWM_NB_CHAN; i++)
+        pwms[pwm][i].on = 0;
+}
+
+#endif /* PWM_NUMOF */

--- a/cpu/native/periph/qdec.c
+++ b/cpu/native/periph/qdec.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Gilles DOFFE <gdoffe@gmail.com>
+ * Copyright (C) 2017 Gilles DOFFE <g.doffe@gmail.com>
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -14,7 +14,7 @@
  * @file
  * @brief       Low-level QDEC driver implementation
  *
- * @author      Gilles DOFFE <gilles.doffe@gmail.com>
+ * @author      Gilles DOFFE <g.doffe@gmail.com>
  *
  * @}
  */

--- a/drivers/include/motor_driver.h
+++ b/drivers/include/motor_driver.h
@@ -1,0 +1,220 @@
+/*
+ * Copyright (C) 2018 Gilles DOFFE <g.doffe@gmail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    drivers_motor DC Motor Driver
+ * @ingroup     drivers_actuators
+ * @brief       High-level driver for DC motors
+ *
+ * This API aims to handle DC motor analogic driver.
+ * Boards using communition protocols (I2C, UART, etc...) are not in the
+ * scope of this driver.
+ * Mainly designed for H-bridge, it could also drive some brushless drivers.
+ *
+ * Some H-bridge handles several motors.
+ * Maximum motor number by H-bridge is set to 2 with MOTOR_DRIVER_MAX macro.
+ * This macro can be overiden to provide more motors by H-bridge.
+ * However, MOTOR_DRIVER_MAX should not exceed PWM channels number.
+ *
+ * motor_driver_t structure represents an H-bridge.
+ * As several H-bridge can share a same PWM device, motor_driver_t can
+ * represent a group of H-bridge.
+ *
+ * Most of H-bridge boards uses the following I/Os for each motor :
+ * - Enable/disable GPIO
+ * - One or two direction GPIOs
+ * - A PWM signal
+ *
+ * @verbatim
+ *
+ * Each motor direction is controlled (assuming it is enabled) according to
+ * the following truth table :
+ *  __________________________
+ * | DIR0 | DIR1 |  BEHAVIOR  |
+ * |--------------------------|
+ * |  0   |  0   | BRAKE LOW  |
+ * |  0   |  1   |     CW     |
+ * |  1   |  0   |     CCW    |
+ * |  1   |  1   | BRAKE HIGH |
+ * |______|______|____________|
+ *
+ * In case of single GPIO for direction, only DIR0 is used without brake
+ * capability :
+ *  ___________________
+ * | DIR0 |  BEHAVIOR  |
+ * |-------------------|
+ * |   0  |     CW     |
+ * |   1  |     CCW    |
+ * |______|____________|
+ *
+ * Some boards add a brake pin with single direction GPIO :
+ *  ________________________
+ * | DIR | BRAKE | BEHAVIOR |
+ * |------------------------|
+ * |  0  |   0   |    CW    |
+ * |  0  |   1   |   BRAKE  |
+ * |  1  |   0   |    CCW   |
+ * |  1  |   1   |   BRAKE  |
+ * |_____|_______|__________|
+ *
+ * @endverbatim
+ *
+ * From this truth tables we can extract three direction states :
+ * - CW (ClockWise)
+ * - CCW (Counter ClockWise)
+ * - BRAKE
+ *
+ * BRAKE LOW is functionnaly the same than BRAKE HIGH but some H-bridge only
+ * brake on BRAKE HIGH due to hardware.
+ * In case of single direction GPIO, there is no BRAKE, PWM duty cycle is set
+ * to 0.
+
+ * @{
+ * @file
+ * @brief       High-level driver for DC motors
+ *
+ * @author      Gilles DOFFE <g.doffe@gmail.com>
+ */
+
+#ifndef MOTOR_DRIVER_H
+#define MOTOR_DRIVER_H
+
+#include "periph/pwm.h"
+#include "periph/gpio.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Maximum number of motors by motor driver
+ */
+#ifndef MOTOR_DRIVER_MAX
+#define MOTOR_DRIVER_MAX    (2)
+#endif /* MOTOR_DRIVER_MAX */
+
+#define MOTOR_DRIVER_DEV(x) (x)
+
+/**
+ * @brief Describe DC motor driver modes
+ */
+typedef enum {
+    MOTOR_DRIVER_2_DIRS         = 0,          /**< 2 GPIOS for direction, \
+                                                    handling BRAKE */
+    MOTOR_DRIVER_1_DIR          = 1,          /**< Single GPIO for direction, \
+                                                    no BRAKE */
+    MOTOR_DRIVER_1_DIR_BRAKE    = 2           /**< Single GPIO for direction, \
+                                                    Single GPIO for BRAKE */
+} motor_driver_mode_t;
+
+/**
+ * @brief Describe DC motor driver brake modes
+ */
+typedef enum {
+    MOTOR_BRAKE_LOW     = 0,        /**< Low stage brake */
+    MOTOR_BRAKE_HIGH    = 1,        /**< High stage brake */
+} motor_driver_mode_brake_t;
+
+/**
+ * @brief Describe DC motor direction states
+ */
+typedef enum {
+    MOTOR_CW      = 0,          /**< clockwise */
+    MOTOR_CCW     = 1,          /**< counter clockwise */
+    MOTOR_BRAKE   = 2           /**< brake */
+} motor_direction_t;
+
+/**
+ * @brief Describe DC motor with PWM channel and GPIOs
+ */
+typedef struct {
+    int pwm_channel;            /**< PWM channel the motor is connected to */
+    gpio_t gpio_enable;         /**< GPIO to enable/disable motor */
+    gpio_t gpio_dir0;           /**< GPIO to control rotation direction */
+    gpio_t gpio_dir1_or_brake;  /**< GPIO to control rotation direction */
+    uint8_t gpio_dir_reverse;   /**< flag to reverse direction */
+    uint8_t gpio_enable_invert; /**< flag to set enable GPIO inverted mode */
+    uint8_t gpio_brake_invert;  /**< flag to make brake active low */
+} motor_t;
+
+/**
+ * @brief   Default motor driver type definition
+ */
+typedef unsigned int motor_driver_t;
+
+/**
+ * @brief   Motor callback. It is called at end of motor_set()
+ */
+typedef void (*motor_driver_cb_t)(const motor_driver_t motor_driver,
+    uint8_t motor_id,
+    motor_direction_t direction, uint16_t pwm_duty_cycle);
+
+/**
+ * @brief Describe DC motor driver with PWM device and motors array
+ */
+typedef struct {
+    pwm_t pwm_dev;                          /**< PWM device driving motors */
+    motor_driver_mode_t mode;               /**< driver mode */
+    motor_driver_mode_brake_t mode_brake;   /**< driver brake mode */
+    uint32_t pwm_frequency;                 /**< PWM device frequency */
+    uint32_t pwm_resolution;                /**< PWM device resolution */
+    uint8_t nb_motors;                      /**< number of moros */
+    motor_t motors[MOTOR_DRIVER_MAX];       /**< motors array */
+    motor_driver_cb_t cb;                   /**< callback on motor_set */
+} motor_driver_config_t;
+
+/**
+ * @brief Initialize DC motor driver board
+ *
+ * @param[out] motor_driver     motor driver to initialize
+ *
+ * @return                      0 on success
+ * @return                      -1 on error with errno set
+ */
+int motor_driver_init(const motor_driver_t motor_driver);
+
+/**
+ * @brief Set motor speed and direction
+ *
+ * @param[in] motor_driver      motor driver to which motor is attached
+ * @param[in] motor_id          motor ID on driver
+ * @param[in] direction         motor direction
+ * @param[in] pwm_duty_cycle    PWM duty_cycle to set motor speed
+ *
+ * @return                      0 on success
+ * @return                      -1 on error with errno set
+ */
+int motor_set(const motor_driver_t motor_driver, uint8_t motor_id, \
+    motor_direction_t direction, uint16_t pwm_duty_cycle);
+
+/**
+ * @brief Enable a motor of a given motor driver
+ *
+ * @param[in] motor_driver      motor driver to which motor is attached
+ * @param[in] motor_id          motor ID on driver
+ *
+ * @return
+ */
+void motor_enable(const motor_driver_t motor_driver, uint8_t motor_id);
+
+/**
+ * @brief Disable a motor of a given motor driver
+ *
+ * @param[in] motor_driver      motor driver to which motor is attached
+ * @param[in] motor_id          motor ID on driver
+ *
+ * @return
+ */
+void motor_disable(const motor_driver_t motor_driver, uint8_t motor_id);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MOTOR_DRIVER_H */
+/** @} */

--- a/drivers/motor_driver/Makefile
+++ b/drivers/motor_driver/Makefile
@@ -1,0 +1,3 @@
+MODULE = motor_driver
+
+include $(RIOTBASE)/Makefile.base

--- a/drivers/motor_driver/motor_driver.c
+++ b/drivers/motor_driver/motor_driver.c
@@ -1,0 +1,209 @@
+#include <errno.h>
+
+/* RIOT includes */
+#include <assert.h>
+#include <board.h>
+#include <log.h>
+#include <motor_driver.h>
+
+#define ENABLE_DEBUG    (0)
+#include <debug.h>
+
+#ifdef MOTOR_DRIVER_NUMOF
+
+#define MOTOR_DRIVER_MODE        PWM_LEFT
+
+int motor_driver_init(motor_driver_t motor_driver)
+{
+    assert(motor_driver < MOTOR_DRIVER_NUMOF);
+
+    const motor_driver_config_t *motor_driver_conf = &motor_driver_config[motor_driver];
+
+    pwm_t pwm_dev = motor_driver_conf->pwm_dev;
+    uint32_t freq = motor_driver_conf->pwm_frequency;
+    uint16_t resol = motor_driver_conf->pwm_resolution;
+
+    uint32_t ret_pwm = pwm_init(pwm_dev, MOTOR_DRIVER_MODE, freq, resol);
+    if (ret_pwm != freq)
+    {
+        errno = EINVAL;
+        LOG_ERROR("pwm_init failed\n");
+        goto motor_init_err;
+    }
+
+    for (uint8_t i = 0; i < motor_driver_conf->nb_motors; i++)
+    {
+        if ((motor_driver_conf->motors[i].gpio_dir0 != GPIO_UNDEF)
+          && (gpio_init(motor_driver_conf->motors[i].gpio_dir0,
+          GPIO_OUT))) {
+            errno = EIO;
+            LOG_ERROR("gpio_dir0 init failed\n");
+            goto motor_init_err;
+        }
+        if ((motor_driver_conf->motors[i].gpio_dir1_or_brake != GPIO_UNDEF)
+          && (gpio_init(motor_driver_conf->motors[i].gpio_dir1_or_brake,
+          GPIO_OUT))) {
+            errno = EIO;
+            LOG_ERROR("gpio_dir1_or_brake init failed\n");
+            goto motor_init_err;
+        }
+        if (motor_driver_conf->motors[i].gpio_enable != GPIO_UNDEF) {
+            if (gpio_init(motor_driver_conf->motors[i].gpio_enable,
+                GPIO_OUT)) {
+                errno = EIO;
+                LOG_ERROR("gpio_enable init failed\n");
+                goto motor_init_err;
+            }
+            motor_enable(motor_driver, i);
+        }
+    }
+
+    return 0;
+
+motor_init_err:
+    return -errno;
+}
+
+int motor_set(const motor_driver_t motor_driver, uint8_t motor_id, \
+    motor_direction_t direction, uint16_t pwm_duty_cycle)
+{
+    assert(motor_driver < MOTOR_DRIVER_NUMOF);
+
+    const motor_driver_config_t *motor_driver_conf = 
+        &motor_driver_config[motor_driver];
+
+    assert(motor_id < motor_driver_conf->nb_motors);
+
+    const motor_t *dev = &motor_driver_conf->motors[motor_id];
+
+    direction = direction ^ dev->gpio_dir_reverse;
+
+    /* Two direction GPIO, handling brake */
+    if (motor_driver_conf->mode == MOTOR_DRIVER_2_DIRS)
+    {
+        if ((dev->gpio_dir0 == GPIO_UNDEF) || \
+            (dev->gpio_dir1_or_brake == GPIO_UNDEF))
+        {
+            errno = ENODEV;
+            goto motor_set_err;
+        }
+        switch (direction)
+        {
+            case MOTOR_CW:
+            case MOTOR_CCW:
+                /* Direction */
+                gpio_write(dev->gpio_dir0, direction);
+                gpio_write(dev->gpio_dir1_or_brake, direction ^ 0x1);
+                break;
+            case MOTOR_BRAKE:
+            default:
+                /* Brake */
+                gpio_write(dev->gpio_dir0,
+                    motor_driver_conf->mode_brake);
+                gpio_write(dev->gpio_dir1_or_brake,
+                    motor_driver_conf->mode_brake);
+                pwm_duty_cycle = 0;
+                break;
+        }
+    }
+    /* Single direction GPIO */
+    else if (motor_driver_conf->mode == MOTOR_DRIVER_1_DIR)
+    {
+        if (dev->gpio_dir0 == GPIO_UNDEF)
+        {
+            errno = ENODEV;
+            goto motor_set_err;
+        }
+        switch (direction)
+        {
+            case MOTOR_CW:
+            case MOTOR_CCW:
+                /* Direction */
+                gpio_write(dev->gpio_dir0, direction);
+                break;
+
+            case MOTOR_BRAKE:
+            default:
+                pwm_duty_cycle = 0;
+                break;
+        }
+    }
+    /* Single direction GPIO and brake GPIO */
+    else if (motor_driver_conf->mode == MOTOR_DRIVER_1_DIR_BRAKE)
+    {
+        if ((dev->gpio_dir0 == GPIO_UNDEF) || \
+            (dev->gpio_dir1_or_brake == GPIO_UNDEF))
+        {
+            errno = ENODEV;
+            goto motor_set_err;
+        }
+        switch (direction)
+        {
+            case MOTOR_CW:
+            case MOTOR_CCW:
+                /* Direction */
+                gpio_write(dev->gpio_dir0, direction);
+                /* No brake */
+                gpio_write(dev->gpio_dir1_or_brake, dev->gpio_brake_invert);
+                break;
+
+            case MOTOR_BRAKE:
+            default:
+                /* No brake */
+                gpio_write(dev->gpio_dir1_or_brake, 1 ^ dev->gpio_brake_invert);
+                pwm_duty_cycle = 0;
+                break;
+        }
+    }
+    else
+    {
+        errno = EINVAL;
+        goto motor_set_err;
+    }
+
+    pwm_set(motor_driver_conf->pwm_dev, dev->pwm_channel, pwm_duty_cycle);
+
+    motor_driver_cb_t cb = motor_driver_conf->cb;
+    if (cb) {
+        cb(motor_driver, motor_id, direction, pwm_duty_cycle);
+    }
+
+    return 0;
+
+motor_set_err:
+    return -errno;
+}
+
+void motor_enable(const motor_driver_t motor_driver, uint8_t motor_id)
+{
+    assert(motor_driver < MOTOR_DRIVER_NUMOF);
+
+    const motor_driver_config_t *motor_driver_conf = 
+        &motor_driver_config[motor_driver];
+
+    assert(motor_id < motor_driver_conf->nb_motors);
+
+    const motor_t *dev = &motor_driver_conf->motors[motor_id];
+
+    assert(dev->gpio_enable != GPIO_UNDEF);
+
+    gpio_write(dev->gpio_enable, 1 ^ dev->gpio_enable_invert);
+}
+
+void motor_disable(const motor_driver_t motor_driver, uint8_t motor_id)
+{
+    assert(motor_driver < MOTOR_DRIVER_NUMOF);
+
+    const motor_driver_config_t *motor_driver_conf = 
+        &motor_driver_config[motor_driver];
+
+    assert(motor_id < motor_driver_conf->nb_motors);
+
+    const motor_t *dev = &motor_driver_conf->motors[motor_id];
+
+    assert(dev->gpio_enable != GPIO_UNDEF);
+
+    gpio_write(dev->gpio_enable, dev->gpio_enable_invert);
+}
+
+#endif /* MOTOR_DRIVER_NUMOF */

--- a/tests/driver_motor_driver/Makefile
+++ b/tests/driver_motor_driver/Makefile
@@ -1,0 +1,17 @@
+include ../Makefile.tests_common
+
+BOARD ?= nucleo-f446re
+
+USEMODULE += motor_driver
+USEMODULE += shell
+USEMODULE += shell_commands
+USEMODULE += xtimer
+
+FEATURES_REQUIRED += periph_pwm
+FEATURES_REQUIRED += periph_qdec
+FEATURES_REQUIRED += periph_gpio
+
+CFLAGS += -DLOG_LEVEL=LOG_DEBUG
+CFLAGS += -DDEBUG_ASSERT_VERBOSE
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/driver_motor_driver/README.md
+++ b/tests/driver_motor_driver/README.md
@@ -1,0 +1,15 @@
+Background
+==========
+
+Test for the high level `motor_driver` driver.
+
+Expected result
+===============
+
+Should do an infinite loop :
+    1) Both motors should turn at half pwm duty cycle speed in clowkwise direction.
+    2) Both motors should turn at full pwm duty cycle speed in clowkwise direction.
+    3) Both motors should brake.
+    4) Both motors should turn at half pwm duty cycle speed in counter clowkwise direction.
+    5) Both motors should turn at full pwm duty cycle speed in counter clowkwise direction.
+    6) Both motors should brake.

--- a/tests/driver_motor_driver/main.c
+++ b/tests/driver_motor_driver/main.c
@@ -1,0 +1,109 @@
+#include <stdio.h>
+#include <string.h>
+
+/* RIOT includes */
+#include <log.h>
+#include <motor_driver.h>
+#include <shell.h>
+#include <shell_commands.h>
+#include <thread.h>
+#include <xtimer.h>
+
+/* set interval to 20 milli-second */
+#define INTERVAL (3000 * US_PER_MS)
+
+#define MOTOR_0_ID  0
+#define MOTOR_1_ID  1
+
+#ifdef MOTOR_DRIVER_NUMOF
+char motion_control_thread_stack[THREAD_STACKSIZE_DEFAULT];
+
+void motors_control(uint16_t duty_cycle, uint8_t dir)
+{
+    char str[6];
+
+    switch (dir) {
+        case (MOTOR_CW):
+            strncpy(str, "CW", 3);
+            break;
+        case (MOTOR_CCW):
+            strncpy(str, "CCW", 4);
+            break;
+        case (MOTOR_BRAKE):
+            strncpy(str, "BRAKE", 6);
+            break;
+        default:
+            strncpy(str, "ERROR", 6);
+    }
+
+    printf("Duty cycle = %u   Direction = %s\n", duty_cycle, str);
+
+    if (motor_set(MOTOR_DRIVER_DEV(0), MOTOR_0_ID, dir, duty_cycle))
+        printf("Cannot set PWM duty cycle for motor %u\n", MOTOR_0_ID);
+    if (motor_set(MOTOR_DRIVER_DEV(0), MOTOR_1_ID, dir, duty_cycle++))
+        printf("Cannot set PWM duty cycle for motor %u\n", MOTOR_1_ID);
+}
+
+void *motion_control_thread(void *arg)
+{
+    uint8_t dir = 0;
+    int ret = 0;
+    xtimer_ticks32_t last_wakeup/*, start*/;
+    uint16_t pwm_res = motor_driver_config[MOTOR_DRIVER_DEV(0)].pwm_resolution;
+
+    (void) arg;
+
+    ret = motor_driver_init(MOTOR_DRIVER_DEV(0));
+    if (ret)
+        LOG_ERROR("motor_driver_init failed with error code %d\n", ret);
+    assert(ret == 0);
+
+    for(;;) {
+        last_wakeup = xtimer_now();
+
+        /* CW - duty cycle 50% */
+        last_wakeup = xtimer_now();
+        motors_control(pwm_res / 2, dir);
+        xtimer_periodic_wakeup(&last_wakeup, INTERVAL);
+
+        /* Disable motor during INTERVAL µs (motor driver must have enable feature */
+        /*last_wakeup = xtimer_now();
+        motor_disable(MOTOR_DRIVER_DEV(0), MOTOR_0_ID);
+        motor_disable(MOTOR_DRIVER_DEV(0), MOTOR_1_ID);
+        xtimer_periodic_wakeup(&last_wakeup, INTERVAL);
+        motor_enable(MOTOR_DRIVER_DEV(0), MOTOR_0_ID);
+        motor_enable(MOTOR_DRIVER_DEV(0), MOTOR_1_ID);*/
+
+        /* CW - duty cycle 100% */
+        last_wakeup = xtimer_now();
+        motors_control(pwm_res, dir);
+        xtimer_periodic_wakeup(&last_wakeup, INTERVAL);
+
+        /* BRAKE - duty cycle 100% */
+        last_wakeup = xtimer_now();
+        motors_control(pwm_res, MOTOR_BRAKE);
+        xtimer_periodic_wakeup(&last_wakeup, INTERVAL);
+
+        /* Reverse direction */
+        dir = dir ? MOTOR_CW : MOTOR_CCW;
+    }
+
+    return NULL;
+}
+#endif /* MOTOR_DRIVER_NUMOF */
+
+int main(void)
+{
+    xtimer_init();
+
+#ifdef MOTOR_DRIVER_NUMOF
+    thread_create(motion_control_thread_stack, sizeof(motion_control_thread_stack),
+                  0, 0,
+                  motion_control_thread, NULL, "motion_ctrl");
+#endif /* MOTOR_DRIVER_NUMOF */
+
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(NULL, line_buf, SHELL_DEFAULT_BUFSIZE);
+
+    return 0;
+}


### PR DESCRIPTION
This driver API aims to control DC motors.
It handles :
 * motor controller associated to a PWM device
 * several motors by controller
 * motor rotation direction
 * brake capability
 * enable/disable motor individually
 * callback on motor_set() calls to perform some actions once PWM is set.

### Contribution description

This contribution is new feature adding an new actuator driver for nearly most kind of analogic H-bridge.
Support for nucleo-f446re board is added.
Support for native board is also added with a QDEC simulation callback. 

### Testing procedure

Go to tests/driver_motor_driver and build with BOARD=native:
`make BOARD=native`
Launch the binary:
`bin/native/tests_driver_motor_driver.elf`
