### PR TITLE
cpu/native: introduce periph_i2c_mock

### DIFF
--- a/cpu/native/Makefile.dep
+++ b/cpu/native/Makefile.dep
@@ -4,12 +4,18 @@ ifeq ($(OS),Linux)
       USEMODULE += periph_gpio_linux
     endif
   endif
+  ifneq (,$(filter periph_i2c,$(USEMODULE)))
+    USEMODULE += periph_i2c_mock
+  endif
   ifneq (,$(filter periph_spi,$(USEMODULE)))
     USEMODULE += periph_spidev_linux
   endif
 else
   ifneq (,$(filter periph_gpio,$(USEMODULE)))
     USEMODULE += periph_gpio_mock
+  endif
+  ifneq (,$(filter periph_i2c,$(USEMODULE)))
+    USEMODULE += periph_i2c_mock
   endif
 endif
 

--- a/cpu/native/Makefile.features
+++ b/cpu/native/Makefile.features
@@ -15,6 +15,7 @@ FEATURES_PROVIDED += periph_eeprom
 FEATURES_PROVIDED += periph_flashpage
 FEATURES_PROVIDED += periph_flashpage_pagewise
 FEATURES_PROVIDED += periph_hwrng
+FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pm
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_timer_periodic

--- a/cpu/native/include/periph_conf.h
+++ b/cpu/native/include/periph_conf.h
@@ -87,6 +87,23 @@ extern "C" {
 #endif
 
 /**
+ * @name I2C configuration (Linux host only)
+ * @{
+ */
+#if !defined(I2C_NUMOF) || defined(DOXYGEN)
+/**
+ * @brief Amount of I2C devices
+ *
+ * Allows up to I2C_NUMOF I2C devices with each having up to I2C_MAXCS hardware
+ * cable select lines. Assignment to hardware devices can be configured at
+ * runtime using the `--spi` startup parameter.
+ *
+ * Can be overridden during compile time with a `-DI2C_NUMOF=n` flag.
+ */
+#define I2C_NUMOF   1
+#endif
+
+/**
  * @name SPI configuration (Linux host only)
  * @{
  */

--- a/cpu/native/include/periph_cpu.h
+++ b/cpu/native/include/periph_cpu.h
@@ -112,6 +112,25 @@ typedef enum {
 #define PROVIDES_PM_SET_LOWEST
 /** @} */
 
+/**
+ * @name I2C Configuration
+ */
+
+#define PERIPH_I2C_NEED_READ_REG    /**< i2c_read_reg required */
+#define PERIPH_I2C_NEED_READ_REGS   /**< i2c_read_regs required */
+#define PERIPH_I2C_NEED_WRITE_REG   /**< i2c_write_reg required */
+#define PERIPH_I2C_NEED_WRITE_REGS  /**< i2c_write_regs required */
+
+#if defined(MODULE_PERIPH_I2C_MOCK) || defined(DOXYGEN)
+/**
+ * @brief   I2C configuration structure type
+ */
+typedef struct {
+    void *dummy;    /**< dummy attribute */
+} i2c_conf_t;
+#endif
+
+
 /* Configuration for the wrapper around the Linux SPI API (periph_spidev_linux)
  *
  * Needs to go here, otherwise the SPI_NEEDS_ are defined after inclusion of

--- a/cpu/native/periph/i2c_mock.c
+++ b/cpu/native/periph/i2c_mock.c
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2024 COGIP Robotics association
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_native
+ * @ingroup     drivers_periph_i2c
+ * @{
+ *
+ * @file
+ * @brief       empty I2C implementation
+ *
+ * @author      Gilles DOFFE <g.doffe@gmail.com>
+ */
+
+#include "periph/i2c.h"
+
+__attribute__((weak)) void i2c_init(i2c_t dev)
+{
+    (void)dev;
+}
+
+__attribute__((weak)) void i2c_acquire(i2c_t dev)
+{
+    (void)dev;
+}
+
+__attribute__((weak)) void i2c_release(i2c_t dev)
+{
+    (void)dev;
+}
+
+__attribute__((weak)) int i2c_read_bytes(i2c_t dev, uint16_t addr,
+                   void *data, size_t len, uint8_t flags)
+{
+    (void)dev;
+    (void)addr;
+    (void)data;
+    (void)len;
+    (void)flags;
+
+    return 0;
+}
+
+__attribute__((weak)) int i2c_write_bytes(i2c_t dev, uint16_t addr, const void *data,
+                    size_t len, uint8_t flags)
+{
+    (void)dev;
+    (void)addr;
+    (void)data;
+    (void)len;
+    (void)flags;
+
+    return 0;
+}

--- a/makefiles/features_modules.inc.mk
+++ b/makefiles/features_modules.inc.mk
@@ -115,7 +115,7 @@ USEMODULE += $(filter arduino_pwm, $(FEATURES_USED))
 
 # always register a peripheral driver as a required feature when the corresponding
 # module is requested
-PERIPH_IGNORE_MODULES += periph_usbdev_clk periph_gpio_mock periph_gpio_linux periph_spidev_linux
+PERIPH_IGNORE_MODULES += periph_usbdev_clk periph_gpio_mock periph_gpio_linux periph_i2c_mock periph_spidev_linux
 
 ifneq (,$(filter periph_%,$(DEFAULT_MODULE)))
   FEATURES_REQUIRED += $(filter-out $(PERIPH_IGNORE_MODULES),$(filter periph_%,$(USEMODULE)))


### PR DESCRIPTION
### Contribution description

This allows I2C emulation on native architecture in the same way than periph_gpio_mock.

All I2C function from this driver are set as weak to be easily overridden in each application.

### Testing procedure

```shell
$ make -C tests/periph/i2c/ BOARD=native
make : on entre dans le répertoire « /home/gdo/Developpement/Informatique/Personnel/cogip/RIOT/tests/periph/i2c »
Building application "tests_i2c" for "native" with MCU "native".

"make" -C /home/gdo/Developpement/Informatique/Personnel/cogip/RIOT/boards/common/init
"make" -C /home/gdo/Developpement/Informatique/Personnel/cogip/RIOT/boards/native
"make" -C /home/gdo/Developpement/Informatique/Personnel/cogip/RIOT/boards/native/drivers
"make" -C /home/gdo/Developpement/Informatique/Personnel/cogip/RIOT/core
"make" -C /home/gdo/Developpement/Informatique/Personnel/cogip/RIOT/core/lib
"make" -C /home/gdo/Developpement/Informatique/Personnel/cogip/RIOT/cpu/native
"make" -C /home/gdo/Developpement/Informatique/Personnel/cogip/RIOT/cpu/native/periph
"make" -C /home/gdo/Developpement/Informatique/Personnel/cogip/RIOT/cpu/native/stdio_native
"make" -C /home/gdo/Developpement/Informatique/Personnel/cogip/RIOT/drivers
"make" -C /home/gdo/Developpement/Informatique/Personnel/cogip/RIOT/drivers/periph_common
"make" -C /home/gdo/Developpement/Informatique/Personnel/cogip/RIOT/sys
"make" -C /home/gdo/Developpement/Informatique/Personnel/cogip/RIOT/sys/auto_init
"make" -C /home/gdo/Developpement/Informatique/Personnel/cogip/RIOT/sys/div
"make" -C /home/gdo/Developpement/Informatique/Personnel/cogip/RIOT/sys/frac
"make" -C /home/gdo/Developpement/Informatique/Personnel/cogip/RIOT/sys/libc
"make" -C /home/gdo/Developpement/Informatique/Personnel/cogip/RIOT/sys/preprocessor
"make" -C /home/gdo/Developpement/Informatique/Personnel/cogip/RIOT/sys/shell
"make" -C /home/gdo/Developpement/Informatique/Personnel/cogip/RIOT/sys/shell/cmds
"make" -C /home/gdo/Developpement/Informatique/Personnel/cogip/RIOT/sys/ztimer
   text	   data	    bss	    dec	    hex	filename
  45915	    844	  47996	  94755	  17223	/home/gdo/Developpement/Informatique/Personnel/cogip/RIOT/tests/periph/i2c/bin/native/tests_i2c.elf
make : on quitte le répertoire « /home/gdo/Developpement/Informatique/Personnel/cogip/RIOT/tests/periph/i2c »
```